### PR TITLE
Clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ date.
 
 ### Jupyter
 
-You can get a Jupyter environment using ihaskell from a nix expression. The one-liner to get an ihaskell lab is (replace `lab` with `notebook` for a notebook):
+You can get a Jupyter environment using ihaskell from a nix expression.  First open a terminal and `cd` into the root directory of the `diagrams-dev` repository.  Then the one-liner to get an ihaskell lab is (replace `lab` with `notebook` for a notebook):
 
 ```
 $(nix-build --no-out-link ihaskell.nix)/bin/ihaskell-lab


### PR DESCRIPTION
Clarify that you have to be in repository root when running e.g. `nix-build ... ihaskell.nix`.  This is obvious in retrospect but I managed to be confused by it, so likely others may be too.